### PR TITLE
Fix for TS2742 (workaround)

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -172,3 +172,8 @@ generic parameter, such as `ErrorClass<[typeof plugin]>`.
 They should only be used to type unknown error instances and classes, when no
 variable nor [type inference](#type-inference) is available. For example, they
 can be useful when [creating plugins](plugins.md#typescript).
+
+## Known limitations and issues
+
+For known limitations and issues related to TypeScript's current capabilities,
+please see the comments in [src/main.d.ts](../src/main.d.ts).

--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -1,28 +1,13 @@
-import type {
-  ErrorClass,
-  SpecificErrorClass,
-  ErrorSubclassCore,
-} from './subclass/create.js'
+import type { ErrorClass, SpecificErrorClass } from './subclass/create.js'
 import type { CustomClass } from './subclass/custom.js'
 
 export type { ErrorInstance } from './merge/cause.js'
 export type { ClassOptions } from './options/class.js'
 export type { InstanceOptions } from './options/instance.js'
 export type { MethodOptions } from './options/method.js'
-export type {
-  Info,
-  // Export required due to
-  // https://github.com/ehmicky/modern-errors/issues/18
-  CommonInfo,
-} from './plugins/info/main.js'
+export type { Info } from './plugins/info/main.js'
 export type { Plugin } from './plugins/shape/main.js'
-export type {
-  ErrorClass,
-  // Exports required due to
-  // https://github.com/ehmicky/modern-errors/issues/18
-  CustomClass,
-  ErrorSubclassCore,
-}
+export type { ErrorClass }
 
 /**
  * Top-level `ErrorClass`.
@@ -86,3 +71,11 @@ export default ModernError
 //    (e.g. `prepareStackTrace()`)
 //  - Plugins should not be allowed to define instance|static methods already
 //    defined by other plugins
+
+// NOTE: The following exports are temporary workarounds for:
+// - [modern-errors issue #18](https://github.com/ehmicky/modern-errors/issues/18)
+// - [TypeScript issue #47663](https://github.com/microsoft/TypeScript/issues/47663)
+export type { CommonInfo } from './plugins/info/main.js'
+export type { CustomClass } from './subclass/custom.js'
+export type { CreateSubclass, ErrorSubclassCore } from './subclass/create.js'
+export type { NormalizeError } from './subclass/normalize.js'

--- a/src/plugins/info/main.d.ts
+++ b/src/plugins/info/main.d.ts
@@ -3,6 +3,13 @@ import type { ErrorClass } from '../../subclass/create.js'
 
 /**
  * Properties shared by all `info` objects.
+ *
+ * @private This type is private and only exported as a temporary workaround
+ * for an open issue with TypeScript. It will be removed in a future release.
+ * See:
+ *
+ * - [modern-errors issue #18](https://github.com/ehmicky/modern-errors/issues/18)
+ * - [TypeScript issue #47663](https://github.com/microsoft/TypeScript/issues/47663)
  */
 interface CommonInfo<Options = never> {
   /**

--- a/src/subclass/create.d.ts
+++ b/src/subclass/create.d.ts
@@ -19,6 +19,13 @@ import type { NormalizeError } from './normalize.js'
 
 /**
  * `ErrorClass.subclass()`
+ *
+ * @private This type is private and only exported as a temporary workaround
+ * for an open issue with TypeScript. It will be removed in a future release.
+ * See:
+ *
+ * - [modern-errors issue #18](https://github.com/ehmicky/modern-errors/issues/18)
+ * - [TypeScript issue #47663](https://github.com/microsoft/TypeScript/issues/47663)
  */
 type CreateSubclass<
   PluginsArg extends Plugins,
@@ -44,6 +51,13 @@ type CreateSubclass<
 
 /**
  * Non-dynamic members of error classes
+ *
+ * @private This type is private and only exported as a temporary workaround
+ * for an open issue with TypeScript. It will be removed in a future release.
+ * See:
+ *
+ * - [modern-errors issue #18](https://github.com/ehmicky/modern-errors/issues/18)
+ * - [TypeScript issue #47663](https://github.com/microsoft/TypeScript/issues/47663)
  */
 interface ErrorSubclassCore<
   PluginsArg extends Plugins,

--- a/src/subclass/custom.d.ts
+++ b/src/subclass/custom.d.ts
@@ -9,6 +9,13 @@ import type { Plugins } from '../plugins/shape/main.js'
 
 /**
  * `custom` option
+ *
+ * @private This type is private and only exported as a temporary workaround
+ * for an open issue with TypeScript. It will be removed in a future release.
+ * See:
+ *
+ * - [modern-errors issue #18](https://github.com/ehmicky/modern-errors/issues/18)
+ * - [TypeScript issue #47663](https://github.com/microsoft/TypeScript/issues/47663)
  */
 export interface CustomClass {
   new (message: string, options?: InstanceOptions): Error

--- a/src/subclass/normalize.d.ts
+++ b/src/subclass/normalize.d.ts
@@ -12,6 +12,13 @@ import type { CustomClass } from './custom.js'
 
 /**
  * `ErrorClass.normalize()`.
+ *
+ * @private This type is private and only exported as a temporary workaround
+ * for an open issue with TypeScript. It will be removed in a future release.
+ * See:
+ *
+ * - [modern-errors issue #18](https://github.com/ehmicky/modern-errors/issues/18)
+ * - [TypeScript issue #47663](https://github.com/microsoft/TypeScript/issues/47663)
  */
 export type NormalizeError<
   PluginsArg extends Plugins,


### PR DESCRIPTION
This fixes #18.

The temporary fix, as discussed in the issue, is to export additional private types. I've grouped all the types being exported for this reason together, at the bottom of [src/main.d.ts](https://github.com/jmchambers/modern-errors/blob/bfeb493bca238113ea978ffbc0d09e8cdffe4d33/src/main.d.ts#L75), and added JSDoc comments in the files where the types are defined, warning that they are private, and won't be exported in the future.

I've tagged the JSDoc comments with `@private` as opposed to `@deprecated`, as the latter was very "noisy" in vscode popovers, and `@private` is closer to the truth anyway. The comments also link to the relevant issues in this repo and the TypeScript repo. I used markdown links, rather than JSDoc `@link` tags, as vscode messes up the formatting of the latter.

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] ~~I have added tests (we are enforcing 100% test coverage).~~
- [x] I have added documentation in the `README.md`, the `docs` directory (if
      any) and the `examples` directory (if any).
- [x] The status checks are successful (continuous integration). Those can be
      seen below.
