### PR TITLE
fix(types): Exports SpecificErrorClass from main.d.ts

### DIFF
--- a/src/main.d.ts
+++ b/src/main.d.ts
@@ -7,7 +7,7 @@ export type { InstanceOptions } from './options/instance.js'
 export type { MethodOptions } from './options/method.js'
 export type { Info } from './plugins/info/main.js'
 export type { Plugin } from './plugins/shape/main.js'
-export type { ErrorClass }
+export type { ErrorClass, SpecificErrorClass }
 
 /**
  * Top-level `ErrorClass`.


### PR DESCRIPTION
Fixes #35

**Which problem is this pull request solving?**

TypeScript error TS2742 when calling subclass with plugins option

**List other issues or pull requests related to this problem**

This fixes #35 

**Describe the solution you've chosen**

Example: I've fixed this by exporting `SpecificErrorClass` from main.d.ts

**Describe alternatives you've considered**

none

**Checklist**

Please add a `x` inside each checkbox:

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md).
- [ ] I have added tests (we are enforcing 100% test coverage).
- [ ] I have added documentation in the `README.md`, the `docs` directory (if
      any)
- [x] The status checks are successful (continuous integration). Those can be
      seen below.
